### PR TITLE
Clean up storing HTTP request data into domino::http::Request

### DIFF
--- a/include/http/request.h
+++ b/include/http/request.h
@@ -90,7 +90,6 @@ class Request {
       } else {
         value = arg.substr(equal_index + 1);
       }
-      printf("key:%s value: %s\n", key.c_str(), value.c_str());
       args_map[key] = value;
       index = next_index;
     }

--- a/include/http/request.h
+++ b/include/http/request.h
@@ -1,11 +1,14 @@
+#ifndef HTTP_REQUEST_H_
+#define HTTP_REQUEST_H_
+
 #include <string>
 #include <string_view>
 #include <unordered_map>
 
-#ifndef HTTP_REQUEST_H_
-#define HTTP_REQUEST_H_
 namespace domino {
 namespace http {
+
+constexpr char kSlash = '/';
 
 enum Method { kGet, kPost, kUnsupported };
 
@@ -23,9 +26,130 @@ inline Method StringToMethod(std::string_view method_as_string) {
 
 class Request {
  public:
+  Request(std::string_view raw_http_request)
+      : raw_http_request(std::string(raw_http_request)) {}
+  void Initialize() {
+    ParseMethodAndEndpointFromHttpRequest();
+    ParseHeadersFromHttpRequest();
+  }
   Method method;
   std::string endpoint;
-  std::unordered_map<std::string, std::string> args;
+  std::unordered_map<std::string, std::string> query;
+  std::unordered_map<std::string, std::string> header;
+
+ private:
+  // return an index instead of making a new string variable?
+  inline std::string GetStringUpToDelimiter(std::string_view given,
+                                            std::string_view delimiter,
+                                            const size_t &start) {
+    size_t end = given.find(delimiter, start);
+    return std::string(given.substr(start, end - start));
+  }
+
+  inline std::string_view RemoveTrailingSlashFromNonEmptyEndpoint(
+      std::string_view endpoint) {
+    // remove any trailing slashes on the parsed endpoint, i.e.
+    // `/path/to/endpoint/` becomes `/path/to/endpoint`. we also
+    // skip the logic if the endpoint is only a single char since it
+    // would be a single slash.
+    if (endpoint.size() > 1 && endpoint[endpoint.size() - 1] == kSlash) {
+      return endpoint.substr(0, endpoint.length() - 1);
+    }
+    return endpoint;
+  }
+
+  // the endpoint parameter looks like /path/to/something or
+  // path/to/something?parameter=1&another=hello
+  void ParseEndpointAndQueryParameters(std::string_view endpoint) {
+    std::unordered_map<std::string, std::string> args_map;
+    // Find Start of Args
+    size_t start = endpoint.find("?");
+    // If npos then no args to read
+    if (start == std::string::npos) {
+      this->endpoint = RemoveTrailingSlashFromNonEmptyEndpoint(endpoint);
+      return;
+    }
+    this->endpoint =
+        RemoveTrailingSlashFromNonEmptyEndpoint(endpoint.substr(0, start));
+
+    // Parses indivdual args
+    size_t index = start;
+    size_t next_index;
+    while (index != std::string::npos) {
+      index++;
+      next_index = endpoint.find("&", index);
+      std::string arg = std::string(endpoint.substr(index, next_index - index));
+      int equal_index = arg.find("=");
+      std::string key = arg.substr(0, equal_index);
+
+      std::string value;
+      // an index of -1 causes to substr to return the entire string
+      // to avoid this, we assign the value to an empty string
+      if (equal_index == -1) {
+        value = "";
+      } else {
+        value = arg.substr(equal_index + 1);
+      }
+      printf("key:%s value: %s\n", key.c_str(), value.c_str());
+      args_map[key] = value;
+      index = next_index;
+    }
+    query = args_map;
+  }
+
+  void ParseMethodAndEndpointFromHttpRequest() {
+    /**
+     * the first line of an HTTP request looks like:
+     * GET /hello.htm HTTP/1.1
+     * this function parses the above string and extracts:
+     * 1. the http request method
+     * 2. the endpoint
+     * 3. any query parameters stored in the endpoint
+     *
+     * these values are stored to the domino::http::Request parameter sent in
+     * as a pointer.
+     *
+     * for example, GET /path/to/something?value=1&another=hi HTTP/1.1 would
+     * extract:
+     * 1. the method as domino::http::Method::kGet
+     * 2. the endpoint as /path/to/something
+     * 3. the query parameters as
+     * {
+     *    "value": "1",
+     *    "another": "hi"
+     * }
+     */
+    size_t http_index = 0;
+    std::string method_as_string =
+        GetStringUpToDelimiter(raw_http_request, " ", http_index);
+    http_index += method_as_string.length() + 1;
+    std::string endpoint_and_args =
+        GetStringUpToDelimiter(raw_http_request, " ", http_index);
+    ParseEndpointAndQueryParameters(endpoint_and_args);
+    method = StringToMethod(method_as_string);
+  }
+
+  void ParseHeadersFromHttpRequest() {
+    size_t http_index = 0;
+    std::string first_line =
+        GetStringUpToDelimiter(raw_http_request, "\r\n", http_index);
+    // we add 2 to account for us finding the \r\n characters
+    http_index += first_line.length() + 2;
+    std::unordered_map<std::string, std::string> header_map;
+    std::string next_line;
+    while (http_index < raw_http_request.length()) {
+      next_line = GetStringUpToDelimiter(raw_http_request, "\r\n", http_index);
+      std::string key = GetStringUpToDelimiter(next_line, ":", 0);
+      if (key.length()) {
+        std::string value =
+            GetStringUpToDelimiter(next_line, "\r\n", key.length() + 2);
+        header_map[key] = value;
+      }
+      http_index += next_line.length() + 2;
+    }
+    header = header_map;
+  }
+  std::string raw_http_request;
 };
 
 }  // namespace http


### PR DESCRIPTION
### how to test
- [ ] manually insert the below snippet into `include/socket_handler.h:237`
```cpp
    printf("done parsing request, \nendpoint: \"%s\"\n",
           request.endpoint.c_str());
    std::cout << "\n\nurl query params:" << std::endl;
    for (auto const &x : request.query) {
      std::cout << x.first          // string (key)
                << ':' << x.second  // string's value
                << std::endl;
    }
    std::cout << "\n\nheader:" << std::endl;
    for (auto const &x : request.header) {
      std::cout << x.first          // string (key)
                << ':' << x.second  // string's value
                << std::endl;
    }
```
- [ ] run the server with `make run`
- [ ] test the endpoint by visiting http://localhost:8080/app/haha?a=1
- [ ] test the endpoint handling POST requests with
```
curl -X POST http://localhost:8080/app/haha?a=1
```
- [ ] ensure the terminal looks something like
```
done parsing request, 
endpoint: "/app/haha"


url query params:
a:1


header:
Host:localhost:8080
Accept-Encoding:gzip, deflate, br
Cache-Control:max-age=0
User-Agent:Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4634.0 Safari/537.36
Accept:text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9
Sec-Fetch-Site:none
Sec-Fetch-User:?1
Connection:keep-alive
sec-ch-ua:"Chromium";v="95", ";Not A Brand";v="99"
Sec-Fetch-Mode:navigate
Upgrade-Insecure-Requests:1
Sec-Fetch-Dest:document
Accept-Language:en-US,en;q=0.9
sec-ch-ua-mobile:?0
sec-ch-ua-platform:"macOS"
```

its lit. the next steps are to abstract parsing all this stuff to live within `domino::http::Request`. after getting that done we can finally register lambdas to handle certain endpoints
