### PR TITLE
move socket initialization and listening logic to domino::handler::SocketHandler

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -14,7 +14,6 @@ int main() {
   signal(SIGINT, signal_handler);
 
   domino::http::Server server(kPort);
-  server.Initialize();
   server.Start();
 
   return 0;


### PR DESCRIPTION
before, SocketHandler's `socket_fd` field was getting reassigned every time we get a new request (when calling `accept`). we should be using the same socket file descriptor when it comes to listening to requests from the server. when accept returns a socket descriptor, that value should be used for parsing the request.

for more info, check out the [man page](https://man7.org/linux/man-pages/man2/accept.2.html) for accept

while we moved logic out of `domino:http::Server`, we need to improve on a socket descriptor being passed around as a parameter to each SocketHandler function. perhaps we return a new object knowing about the new socket descriptor returned by `accept`, and the object contains methods for reading data from said socket?
